### PR TITLE
Fix typing issue with charge count

### DIFF
--- a/src/app/from-blason/form/CountAndDispositionForm.tsx
+++ b/src/app/from-blason/form/CountAndDispositionForm.tsx
@@ -14,6 +14,7 @@ type Props = {
 };
 export const CountAndDispositionForm = ({ countAndDisposition, countAndDispositionChange }: Props) => {
   function countChange(count: SupportedNumber) {
+    count = parseInt(count);
     countAndDispositionChange({ count, disposition: count === 1 ? 'default' : countAndDisposition.disposition });
   }
 


### PR DESCRIPTION
An error occurred when changing the number inside the Charge panel to 1, due to a typing issue.
This patch fixes it (although there may be better ways to do it, as I am neither familiar with TypeScript nor the codebase).